### PR TITLE
append newline to response body

### DIFF
--- a/metadatafs/metadatafs.go
+++ b/metadatafs/metadatafs.go
@@ -141,7 +141,8 @@ func (fs *MetadataFs) Open(name string, flags uint32, context *fuse.Context) (fi
 			return nil, fuse.EIO
 		}
 
-		return nodefs.NewDataFile(body), fuse.OK
+		newlinebody := append(body, 0x0a) // newline
+		return nodefs.NewDataFile(newlinebody), fuse.OK
 	default:
 		log.Printf("[ERROR] unknown HTTP status code from AWS metadata API: %d", resp.StatusCode)
 		return nil, fuse.EIO


### PR DESCRIPTION
Unlike the proc pseudo file system, the 169.254.169.254 service doesn't end the body with a newline.
This appends a newline to the body in ec2-metadatafs.

```
[ec2-user@ip-172-31-5-181 ~]$ curl -s http://169.254.169.254/latest/meta-data/instance-id
i-0110fccf792a8e764[ec2-user@ip-172-31-5-181 ~]$ 

[ec2-user@ip-172-31-5-181 ~]$ cat /aws/meta-data/instance-id
i-0110fccf792a8e764
[ec2-user@ip-172-31-5-181 ~]$ 

[ec2-user@ip-172-31-5-181 ~]$ cat /proc/cmdline 
root=LABEL=/ console=ttyS0 LANG=en_US.UTF-8 KEYTABLE=us
```
