### PR TITLE
Unmount the FS when sent SIGTERM or SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 Bug fixes:
 * Wait for daemonized process to notify when mounting before exiting. This will
   help users determine if it mounted correctly or not.
+* Unmount when process is sent SIGINT or SIGTERM
 
 ## 0.3.0 (August 23, 2016)
 

--- a/main.go
+++ b/main.go
@@ -244,6 +244,18 @@ func prepareServer(options *Options, logger *logging.Logger) *fuse.Server {
 		}()
 	}
 
+	// Unmount when the process exits
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ch
+		err := server.Unmount()
+		if err != nil {
+			logger.Warningf("could not unmount: %s", err)
+		}
+		os.Exit(1)
+	}()
+
 	return server
 }
 


### PR DESCRIPTION
Otherwise the mountpoint persists and must be unmounted manually after
exit.
